### PR TITLE
Add document stylesheet reuse

### DIFF
--- a/style-shelter.js
+++ b/style-shelter.js
@@ -118,6 +118,14 @@ export default {
             return this._dict.get(url);
         } else {
             const sheet = new CSSStyleSheet();
+
+            const documentSheet = Array(...document.styleSheets).find(styleSheet => styleSheet.href.includes(url));
+            if (documentSheet) {
+              sheet.replace(Array(...documentSheet.rules).map(rule => rule.cssText).join(' '));
+              this._dict.set(url, sheet);
+              return sheet;
+            }
+
             fetch(url)
                 .then(response => response.text())
                 .then(data => {


### PR DESCRIPTION
I noticed that sometimes when using this script the same css files would end up being retrieved 2 times. Once for the `fetch` and once if it was used as a <link> in the main window document. This will look at the existing stylesheets of the main document and recreate them as constructed stylesheets for re-use in all style-shelter contexts.